### PR TITLE
rewrite axis_stops_estimation procedure

### DIFF
--- a/procedures/axis_stops_estimation.sql
+++ b/procedures/axis_stops_estimation.sql
@@ -6,7 +6,7 @@ as
 $$
 begin
     -- skip percentile calculations if there's overrides for min, p25, p75, max
-    if exists (select 1 from bivariate_axis_overrides
+    if exists (select from bivariate_axis_overrides
                where numerator_id = x_numerator_uuid
                  and denominator_id = x_denominator_uuid
                  and min is not null


### PR DESCRIPTION
current best result for the query: 4 minutes (with 4 parallel workers)
```
sleeping ~/konturio/insights-db$ cat ../dbdump/custom-axis_stops_estimation.sql
set work_mem='10GB';
explain verbose -- (analyze, verbose, buffers, settings)
        select
            percentile_disc(array[0, .33, .66, 1])
                within group (order by a.indicator_value / b.indicator_value::double precision) as percentiles
        -- order 2 sets by h3 so that merge join is preferable for the planner
        from (
            select h3, indicator_value
            from stat_h3_transposed
            where indicator_uuid = '37d77aab-2f76-420f-8dbc-c6ca84801d42' and indicator_value != 0
            order by indicator_uuid, h3) a
        join (
            select h3, indicator_value
            from stat_h3_transposed
            where indicator_uuid = '4b617e43-75f7-400b-808c-8e8a0418131a' and indicator_value != 0
            order by indicator_uuid, h3) b on (a.h3 = b.h3)
sleeping ~/konturio/insights-db$ psql -h localhost -p 5444 -U insights-api -f !^
psql -h localhost -p 5444 -U insights-api -f ../dbdump/custom-axis_stops_estimation.sql
Password for user insights-api: 
SET
                                                                              QUERY PLAN                                                                              
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=211172045.53..211172045.54 rows=1 width=32)
   Output: percentile_disc('{0,0.33,0.66,1}'::double precision[]) WITHIN GROUP (ORDER BY (stat_h3_transposed_1.indicator_value / stat_h3_transposed.indicator_value))
   ->  Merge Join  (cost=161651807.06..210490448.24 rows=136319458 width=16)
         Output: stat_h3_transposed_1.indicator_value, stat_h3_transposed.indicator_value
         Merge Cond: (stat_h3_transposed.h3 = stat_h3_transposed_1.h3)
         ->  Gather Merge  (cost=82469049.71..107080594.62 rows=205550748 width=32)
               Output: stat_h3_transposed.h3, stat_h3_transposed.indicator_value, stat_h3_transposed.indicator_uuid
               Workers Planned: 4
               ->  Sort  (cost=82468049.65..82596518.87 rows=51387687 width=32)
                     Output: stat_h3_transposed.h3, stat_h3_transposed.indicator_value, stat_h3_transposed.indicator_uuid
                     Sort Key: stat_h3_transposed.h3
                     ->  Parallel Bitmap Heap Scan on public.stat_h3_transposed  (cost=4527252.26..75886592.35 rows=51387687 width=32)
                           Output: stat_h3_transposed.h3, stat_h3_transposed.indicator_value, stat_h3_transposed.indicator_uuid
                           Recheck Cond: (stat_h3_transposed.indicator_uuid = '4b617e43-75f7-400b-808c-8e8a0418131a'::uuid)
                           Filter: (stat_h3_transposed.indicator_value <> '0'::double precision)
                           ->  Bitmap Index Scan on stat_h3_transposed_indicator_uuid_h3_idx_new  (cost=0.00..4475864.58 rows=233026956 width=0)
                                 Index Cond: (stat_h3_transposed.indicator_uuid = '4b617e43-75f7-400b-808c-8e8a0418131a'::uuid)
         ->  Materialize  (cost=79182757.36..99100710.11 rows=150625833 width=16)
               Output: stat_h3_transposed_1.h3, stat_h3_transposed_1.indicator_value, stat_h3_transposed_1.indicator_uuid
               ->  Gather Merge  (cost=79182757.36..97217887.20 rows=150625832 width=32)
                     Output: stat_h3_transposed_1.h3, stat_h3_transposed_1.indicator_value, stat_h3_transposed_1.indicator_uuid
                     Workers Planned: 4
                     ->  Sort  (cost=79181757.30..79275898.44 rows=37656458 width=32)
                           Output: stat_h3_transposed_1.h3, stat_h3_transposed_1.indicator_value, stat_h3_transposed_1.indicator_uuid
                           Sort Key: stat_h3_transposed_1.h3
                           ->  Parallel Bitmap Heap Scan on public.stat_h3_transposed stat_h3_transposed_1  (cost=3317531.40..74443371.01 rows=37656458 width=32)
                                 Output: stat_h3_transposed_1.h3, stat_h3_transposed_1.indicator_value, stat_h3_transposed_1.indicator_uuid
                                 Recheck Cond: (stat_h3_transposed_1.indicator_uuid = '37d77aab-2f76-420f-8dbc-c6ca84801d42'::uuid)
                                 Filter: (stat_h3_transposed_1.indicator_value <> '0'::double precision)
                                 ->  Bitmap Index Scan on stat_h3_transposed_indicator_uuid_h3_idx_new  (cost=0.00..3279874.94 rows=170760164 width=0)
                                       Index Cond: (stat_h3_transposed_1.indicator_uuid = '37d77aab-2f76-420f-8dbc-c6ca84801d42'::uuid)
 Query Identifier: 7047692370424312359
(32 rows)
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Modified `axis_stops_estimation` procedure to skip percentile calculations under certain conditions and adjust `work_mem` setting.
  - Changed the calculation of `min`, `p25`, `p75`, and `max` values using percentiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->