### PR TITLE
use MAX_PARALLEL_TASKS var

### DIFF
--- a/scripts/do_tasks.sh
+++ b/scripts/do_tasks.sh
@@ -8,6 +8,6 @@ while true; do
         echo "postgres not ready, $0 is waiting..."
         sleep 120
     fi
-    seq `psql -c 'select count(0) from task_queue' -t` | parallel -j 100% -n0 "psql -q -c 'call dispatch()'"
+    seq `psql -c 'select count(0) from task_queue' -t` | parallel -j ${MAX_PARALLEL_TASKS:=3} -n0 "psql -q -c 'call dispatch()'"
     sleep 10
 done


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated parallel task limit parameter in the shell script to use a variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->