### PR TITLE
run scripts/remove_duplicated_h3.sql once a day

### DIFF
--- a/procedures/dispatch.sql
+++ b/procedures/dispatch.sql
@@ -44,7 +44,7 @@ begin
         return;
     end if;
 
-    execute 'set application_name to ' || quote_literal('insights-db ' || coalesce(task, ''));
+    execute 'set application_name to ' || quote_literal('insights-db ' || coalesce(task, '') || ' ' || coalesce(left(x_num::text,8),'') || ' ' || coalesce(left(x_den::text, 8),''));
     raise notice '[%] start % task tid=% for %, %, %, %', pg_backend_pid(), task, task_id, x_num, x_den, y_num, y_den;
 
     if task = 'system_indicators' then

--- a/procedures/transformations.sql
+++ b/procedures/transformations.sql
@@ -145,8 +145,8 @@ begin
                 raise notice 'cannot take logarithm of a negative number, need to recalculate layer_min';
                 -- sometimes min_value in bivariate_axis_v2 gets outdated, so log(x-min(x)<0) may occur.
                 -- try to repair it by recalculating analytics
-                insert into task_queue (task_type, x_numerator_id, x_denominator_id, priority)
-                values ('analytics', x_numerator_uuid, x_denominator_uuid, 2.0)
+                insert into task_queue (task_type, x_numerator_id, x_denominator_id, priority, created_at)
+                values ('analytics', x_numerator_uuid, x_denominator_uuid, 2.0, now()-interval '1 day')
                 on conflict do nothing;
                 set task.rc = 1;
             else


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced a task to remove duplicated entries from the database, enhancing data integrity.
  - Added a new task in the build process to manage potential duplication issues related to H3 geometries.
  - Enhanced SQL procedures to improve task tracking with timestamps and prevent duplicate entries.

- **Bug Fixes**
  - Improved application name logging for better traceability during task execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->