### PR TITLE
restrict system_indicators, stat_h3_geom to 8 res; skip transformatio…

### DIFF
--- a/procedures/calculate_system_indicators.sql
+++ b/procedures/calculate_system_indicators.sql
@@ -27,6 +27,7 @@ begin
         select h3
         from stat_h3_transposed a
         where a.indicator_uuid = x_numerator_uuid
+          and h3_get_resolution(h3) <= 8
           and not exists (
             select from stat_h3_transposed b
             where b.indicator_uuid = one_uuid and b.h3 = a.h3

--- a/procedures/transformations.sql
+++ b/procedures/transformations.sql
@@ -23,6 +23,14 @@ begin
         return;
     end if;
 
+    if 0.5 > (select coalesce(quality,1) from bivariate_axis_v2 ba
+                where ba.numerator_uuid = x_numerator_uuid
+                  and ba.denominator_uuid = x_denominator_uuid) then
+        -- no need to find transformation for low quality axis
+        return;
+    end if;
+
+
     -- bivariate_axis_v2.min is floor() of minimal value of all hexagons for all resolutions.
     -- all further calculations are also performed on hexes of all resolutions
     select min, mean_all_res, stddev_all_res into layer_min, layer_mean, layer_stddev from bivariate_axis_v2

--- a/scripts/update_stat_h3_geom.sql
+++ b/scripts/update_stat_h3_geom.sql
@@ -5,6 +5,7 @@ SELECT t.h3,
 FROM (
     SELECT DISTINCT h3 FROM stat_h3_transposed
     where indicator_uuid in (select internal_id from bivariate_indicators_metadata where date > now() - interval '2 days')
+      and h3_get_resolution(h3) <= 8
     order by h3
 ) t
 WHERE NOT exists (SELECT FROM stat_h3_geom g WHERE g.h3 = t.h3)


### PR DESCRIPTION
…ns for low quality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced data processing by adding a resolution filter to H3 indices in system indicators and transformations.
	- Early exit for low-quality axis checks in transformation calculations.
  
- **Bug Fixes**
	- Improved data selection for H3 values in the geometry update script to ensure only relevant indices are processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->