### PR TITLE
remove 2h timeout from tasks for copy to complete

### DIFF
--- a/scripts/do_tasks.sh
+++ b/scripts/do_tasks.sh
@@ -9,6 +9,6 @@ while true; do
         sleep 120
         continue
     fi
-    seq `psql -c 'select count(0) from task_queue' -t` | parallel -j ${MAX_PARALLEL_TASKS:=3} -n0 'psql -q -c "set statement_timeout = '\''2h'\''; call dispatch()"'
+    seq `psql -c 'select count(0) from task_queue' -t` | parallel -j ${MAX_PARALLEL_TASKS:=3} -n0 'psql -q -c "call dispatch()"'
     sleep 10
 done


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed PostgreSQL statement timeout constraint for task dispatching, allowing tasks to potentially run without time limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->