### PR TITLE
reindex-bloated-btree-daily

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 
 .PHONY: all
-all: task_scheduler remove_failed_upload_loop monitor_pg_stats_loop remove_outated_indicators_loop insights_tasks_loop apply_overrides_loop geometry reporting
+all: task_scheduler remove_failed_upload_loop monitor_pg_stats_loop remove_outated_indicators_loop insights_tasks_loop apply_overrides_loop reindex_btree_loop geometry reporting
 
 
 .PHONY: insights_tasks_loop
@@ -24,6 +24,10 @@ apply_overrides_loop:
 .PHONY: remove_outated_indicators_loop
 remove_outated_indicators_loop:
 	$(SHELL) scripts/remove_outated_indicators.sh
+
+.PHONY: reindex_btree_loop
+reindex_btree_loop:
+	$(SHELL) scripts/reindex-bloated-btrees.sh
 
 .PHONY: remove_failed_upload_loop
 remove_failed_upload_loop:

--- a/scripts/btree_bloat-superuser.sql
+++ b/scripts/btree_bloat-superuser.sql
@@ -1,0 +1,105 @@
+-- Copyright (c) 2015-2019, Jehan-Guillaume (ioguix) de Rorthais
+-- All rights reserved.
+-- 
+-- Redistribution and use in source and binary forms, with or without
+-- modification, are permitted provided that the following conditions are met:
+-- 
+-- * Redistributions of source code must retain the above copyright notice, this
+--   list of conditions and the following disclaimer.
+-- 
+-- * Redistributions in binary form must reproduce the above copyright notice,
+--   this list of conditions and the following disclaimer in the documentation
+--   and/or other materials provided with the distribution.
+-- 
+-- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+-- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-- DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+-- FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+-- DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+-- SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+-- CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+-- OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+-- OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+-- below is modified version of https://github.com/ioguix/pgsql-bloat-estimation/blob/master/btree/btree_bloat-superuser.sql
+-- it returns names of the tables that have bloated btree indexes (>50%)
+
+SELECT
+  tblname
+FROM (
+  SELECT coalesce(1 +
+         ceil(reltuples/floor((bs-pageopqdata-pagehdr)/(4+nulldatahdrwidth)::float)), 0 -- ItemIdData size + computed avg size of a tuple (nulldatahdrwidth)
+      ) AS est_pages,
+      coalesce(1 +
+         ceil(reltuples/floor((bs-pageopqdata-pagehdr)*fillfactor/(100*(4+nulldatahdrwidth)::float))), 0
+      ) AS est_pages_ff,
+      bs, nspname, tblname, idxname, relpages, fillfactor, is_na
+      -- , pgstatindex(idxoid) AS pst, index_tuple_hdr_bm, maxalign, pagehdr, nulldatawidth, nulldatahdrwidth, reltuples -- (DEBUG INFO)
+  FROM (
+      SELECT maxalign, bs, nspname, tblname, idxname, reltuples, relpages, idxoid, fillfactor,
+            ( index_tuple_hdr_bm +
+                maxalign - CASE -- Add padding to the index tuple header to align on MAXALIGN
+                  WHEN index_tuple_hdr_bm%maxalign = 0 THEN maxalign
+                  ELSE index_tuple_hdr_bm%maxalign
+                END
+              + nulldatawidth + maxalign - CASE -- Add padding to the data to align on MAXALIGN
+                  WHEN nulldatawidth = 0 THEN 0
+                  WHEN nulldatawidth::integer%maxalign = 0 THEN maxalign
+                  ELSE nulldatawidth::integer%maxalign
+                END
+            )::numeric AS nulldatahdrwidth, pagehdr, pageopqdata, is_na
+            -- , index_tuple_hdr_bm, nulldatawidth -- (DEBUG INFO)
+      FROM (
+          SELECT n.nspname, ct.relname AS tblname, i.idxname, i.reltuples, i.relpages,
+              i.idxoid, i.fillfactor, current_setting('block_size')::numeric AS bs, 
+              CASE -- MAXALIGN: 4 on 32bits, 8 on 64bits (and mingw32 ?)
+                WHEN version() ~ 'mingw32' OR version() ~ '64-bit|x86_64|ppc64|ia64|amd64' THEN 8
+                ELSE 4
+              END AS maxalign,
+              /* per page header, fixed size: 20 for 7.X, 24 for others */
+              24 AS pagehdr,
+              /* per page btree opaque data */
+              16 AS pageopqdata,
+              /* per tuple header: add IndexAttributeBitMapData if some cols are null-able */
+              CASE WHEN max(coalesce(s.stanullfrac,0)) = 0
+                  THEN 8 -- IndexTupleData size
+                  ELSE 8 + (( 32 + 8 - 1 ) / 8) -- IndexTupleData size + IndexAttributeBitMapData size ( max num filed per index + 8 - 1 /8)
+              END AS index_tuple_hdr_bm,
+              /* data len: we remove null values save space using it fractionnal part from stats */
+              sum( (1-coalesce(s.stanullfrac, 0)) * coalesce(s.stawidth, 1024)) AS nulldatawidth,
+              max( CASE WHEN a.atttypid = 'pg_catalog.name'::regtype THEN 1 ELSE 0 END ) > 0 AS is_na
+          FROM (
+              SELECT idxname, reltuples, relpages, tbloid, idxoid, fillfactor,
+                  CASE WHEN indkey[i]=0 THEN idxoid ELSE tbloid END AS att_rel,
+                  CASE WHEN indkey[i]=0 THEN i ELSE indkey[i] END AS att_pos
+              FROM (
+                  SELECT idxname, reltuples, relpages, tbloid, idxoid, fillfactor, indkey, generate_series(1,indnatts) AS i
+                  FROM (
+                      SELECT ci.relname AS idxname, ci.reltuples, ci.relpages, i.indrelid AS tbloid,
+                          i.indexrelid AS idxoid,
+                          coalesce(substring(
+                              array_to_string(ci.reloptions, ' ')
+                              from 'fillfactor=([0-9]+)')::smallint, 90) AS fillfactor,
+                          i.indnatts,
+                          string_to_array(textin(int2vectorout(i.indkey)),' ')::int[] AS indkey
+                      FROM pg_index i
+                      JOIN pg_class ci ON ci.oid=i.indexrelid
+                      WHERE ci.relam=(SELECT oid FROM pg_am WHERE amname = 'btree')
+                        AND ci.relpages > 0
+                        and ci.relname ~ 'transposed'
+                  ) AS idx_data
+              ) AS idx_data_cross
+          ) i
+          JOIN pg_attribute a ON a.attrelid = i.att_rel
+                             AND a.attnum = i.att_pos
+          JOIN pg_statistic s ON s.starelid = i.att_rel
+                             AND s.staattnum = i.att_pos
+          JOIN pg_class ct ON ct.oid = i.tbloid
+          JOIN pg_namespace n ON ct.relnamespace = n.oid
+          GROUP BY 1,2,3,4,5,6,7,8,9,10
+      ) AS rows_data_stats
+  ) AS rows_hdr_pdg_stats
+) AS relation_stats
+WHERE 100 * (relpages-est_pages_ff)::float / relpages > 50 -- bloat_pct
+ORDER BY idxname

--- a/scripts/reindex-bloated-btrees.sh
+++ b/scripts/reindex-bloated-btrees.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+while true; do
+    partitions=`psql -Atqf scripts/btree_bloat-superuser.sql`
+
+    if [ -n "$partitions" ]; then
+        # reindex partitions in 5 parallel jobs (more jobs will provoke OOM killer)
+        command="reindexdb --concurrently -v -j 5 $(for p in $partitions; do echo -n ' -t ' $p; done)"
+        echo reindexing $partitions
+        eval $command
+    else
+        echo "nothing to reindex"
+    fi
+    sleep 1d
+done


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Added an automated maintenance routine that regularly detects and reindexes bloated database indexes to reduce bloat and improve query performance.
  * Integrated this routine into the standard operational loop so it runs by default without manual intervention.
  * Executes with controlled concurrency to minimize impact on availability and resource usage, providing safer, incremental performance upkeep over time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->