### PR TITLE
cleanup invalid indexes before reindex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ remove_outated_indicators_loop:
 
 .PHONY: reindex_btree_loop
 reindex_btree_loop:
+	psql -qf scripts/drop_invalid_indexes.sql
 	$(SHELL) scripts/reindex-bloated-btrees.sh
 
 .PHONY: remove_failed_upload_loop

--- a/scripts/btree_bloat-superuser.sql
+++ b/scripts/btree_bloat-superuser.sql
@@ -25,7 +25,7 @@
 -- below is modified version of https://github.com/ioguix/pgsql-bloat-estimation/blob/master/btree/btree_bloat-superuser.sql
 -- it returns names of the tables that have bloated btree indexes (>50%)
 
-SELECT
+SELECT DISTINCT
   tblname
 FROM (
   SELECT coalesce(1 +
@@ -102,4 +102,4 @@ FROM (
   ) AS rows_hdr_pdg_stats
 ) AS relation_stats
 WHERE 100 * (relpages-est_pages_ff)::float / relpages > 50 -- bloat_pct
-ORDER BY idxname
+ORDER BY 1

--- a/scripts/drop_invalid_indexes.sql
+++ b/scripts/drop_invalid_indexes.sql
@@ -1,0 +1,31 @@
+DO $$
+DECLARE
+    idx RECORD;
+BEGIN
+    FOR idx IN
+        SELECT n.nspname AS schema_name,
+               c.relname AS index_name,
+               t.oid AS table_oid,
+               t.relname AS table_name
+        FROM pg_index i
+        JOIN pg_class c ON c.oid = i.indexrelid
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        JOIN pg_class t ON t.oid = i.indrelid
+        WHERE NOT i.indisvalid
+    LOOP
+        BEGIN
+            -- try to take an ACCESS EXCLUSIVE lock on the table, without waiting
+            EXECUTE format('LOCK TABLE %I.%I IN ACCESS EXCLUSIVE MODE NOWAIT',
+                           idx.schema_name, idx.table_name);
+
+            -- if lock succeeds, drop index
+            RAISE NOTICE 'Dropping invalid index: %.%', idx.schema_name, idx.index_name;
+            EXECUTE format('DROP INDEX IF EXISTS %I.%I;', idx.schema_name, idx.index_name);
+
+        EXCEPTION WHEN lock_not_available THEN
+            RAISE NOTICE 'Skipped index %.% (table %.% is busy)', 
+                         idx.schema_name, idx.index_name, idx.schema_name, idx.table_name;
+        END;
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically detects and drops invalid PostgreSQL indexes during maintenance, improving cluster health with minimal disruption.

* **Bug Fixes**
  * Reduces reindex failures by running invalid-index cleanup before btree reindexing.
  * De-duplicates btree bloat report results and standardizes sorting for clearer output.

* **Chores**
  * Updates maintenance workflow to include an additional pre-reindex safety step for smoother operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->